### PR TITLE
Fix typo in README Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ This is to provide the option of user-defined health checks.
   check:
     - type: command
       command: "ping -c 192.168.200.10"
-      status 0
+      status: 0
 ```
 
 ## License


### PR DESCRIPTION
Missing a colon for the `status` field of the ping command example.